### PR TITLE
Handle LastPass entries that are categorized

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 .DS_Store
-
+.vscode

--- a/LastPass Entries.lbaction/Contents/Scripts/default.js
+++ b/LastPass Entries.lbaction/Contents/Scripts/default.js
@@ -28,12 +28,19 @@ function run(argument) {
         
         entriesList = entriesArray.map(
             function (entry) {
-                parts = entry.match(/(\(.*\))\/(.*)\[id: ([0-9]*)\] \[username: ([^]*)\]/)
+                parts = entry
+                    .substring(17) // remove date/timestamp
+                    .match(/^(.*?)\[id: ([0-9]*)\] \[username: (.*)\]/);
+
                 if (parts) {
+                    title = parts[1].match(/([^/]+)?$/)[1]; // this regex removes any LastPass categories in the title string, you could also keep them with just: parts[1];
+                    id = parts[2];
+                    userName = parts[3];
+
                     return {
-                        'title': parts[2] + '(' + (parts[4] || '?') + ')',
+                        'title': `${title}(${userName || "?"})`,
                         'action': 'getInfo',
-                        'actionArgument': parts[3],
+                        'actionArgument': id,
                         'actionReturnsItems': true
                     };
     


### PR DESCRIPTION
For some reason the LaunchBar action was limited to only the `(none)` category of my LastPass entries. I'm not totally sure why it was failing, but this PR fixes that issue for me.

Also, when LastPass entries are categorized their `name` is a string with the categories prepended with `/`s (eg: for a `github.com` login catergorized under `Web Dev` you get: `Web Dev/github.com`) There can be sub categorizations too. In any case, on line 36 in this PR I used regex to get *just* the `name` for a cleaner UI, but this is optional.